### PR TITLE
Prevents VES from running on CloudFlare page - Closes #42

### DIFF
--- a/builds/voat-enhancement-suite.user.js
+++ b/builds/voat-enhancement-suite.user.js
@@ -19,7 +19,7 @@
 // ==/UserScript==
 
 /*
-*	Voat Enhancement Suite - Version 0.0.3 - 2015-07-18
+*	Voat Enhancement Suite - Version 0.0.3 - 2015-08-10
 *
 *	Licensed under GNU General Public License.
 *	https://github.com/travis-g/Voat-Enhancement-Suite/blob/master/LICENSE
@@ -665,6 +665,15 @@ Utils = {
 		this.isDarkModeCached = $('body').hasClass('dark');
 		return this.isDarkModeCached;
 	},
+	isCloudFlarePage: function() {
+		// check if user is on the CloudFlare page
+		if ($('form#challenge-form').length > 0) {
+			alert('Is CloudFlare');
+			return true;
+		}
+
+		return false;
+	}
 };
 
 var SettingsConsole = '';
@@ -2022,11 +2031,14 @@ Modules.voatingNeverEnds = {
 
 	var VES = { // for the extension itself
 		preInit: function() {
-			//@TODO check if VES should run
-			// VES shouldn't run/show on the API or CloudFlare pages
+			//@TODO disable VES on the API
+			if (!Utils.isCloudFlarePage()) {
+				// see if we can access storage(s):
+				//@TODO this was never run before so I'm not gonna run it now
+				//this.testStorage();
 
-			// see if we can access storage(s):
-			this.testStorage();
+				this.init();
+			}
 		},
 		init: function() {
 			this.loadOptions();
@@ -2114,6 +2126,12 @@ Modules.voatingNeverEnds = {
 			}
 		}
 	};
-	VES.init();
+
+	//waiting for document to load so we can check
+	//for API or CloudFlare page
+	$(document).ready(function() {
+		VES.preInit();
+	});
+
 
 }).call(this);

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -2,11 +2,14 @@
 
 	var VES = { // for the extension itself
 		preInit: function() {
-			//@TODO check if VES should run
-			// VES shouldn't run/show on the API or CloudFlare pages
+			//@TODO disable VES on the API
+			if (!Utils.isCloudFlarePage()) {
+				// see if we can access storage(s):
+				//@TODO this was never run before so I'm not gonna run it now
+				//this.testStorage();
 
-			// see if we can access storage(s):
-			this.testStorage();
+				this.init();
+			}
 		},
 		init: function() {
 			this.loadOptions();
@@ -94,6 +97,12 @@
 			}
 		}
 	};
-	VES.init();
+
+	//waiting for document to load so we can check
+	//for API or CloudFlare page
+	$(document).ready(function() {
+		VES.preInit();
+	});
+
 
 }).call(this);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -240,4 +240,13 @@ Utils = {
 		this.isDarkModeCached = $('body').hasClass('dark');
 		return this.isDarkModeCached;
 	},
+	isCloudFlarePage: function() {
+		// check if user is on the CloudFlare page
+		if ($('form#challenge-form').length > 0) {
+			alert('Is CloudFlare');
+			return true;
+		}
+
+		return false;
+	}
 };


### PR DESCRIPTION
* Adds a method to Utils to check for the CloudFlare page
* Uses `preInit` before `init` so we can run checks like CloudFlare or API
* Prevents `asap` functions from running though because we need to wait for the HTML to finish loading to check if the page is a CloudFlare page.